### PR TITLE
Add support for decoding version and vendor_consents from core segment

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+transparency_and_consent-*.tar
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TransparencyAndConsent
 
-Decode IAB Transparency and Consent Framework 2.0 strings.
+Decode IAB Transparency and Consent Framework v1.1 & v2.0 strings.
 
 Currently only decodes the version, and the list of vendor consents for maximum performance.
 

--- a/lib/transparency_and_consent.ex
+++ b/lib/transparency_and_consent.ex
@@ -1,6 +1,6 @@
 defmodule TransparencyAndConsent do
   @moduledoc """
-  IAB Transparency and Consent Framework v2.0 String Decoding
+  IAB Transparency and Consent Framework v1.1 & v2.0 String Decoding.
 
   Currently only decodes the "version" and the "vendor consents" parts of the "core" segment.
   """
@@ -20,7 +20,7 @@ defmodule TransparencyAndConsent do
   ]
 
   @doc """
-  Decodes TCF version 2 strings.
+  Decodes TCF strings.
 
   ## Examples
 

--- a/lib/transparency_and_consent.ex
+++ b/lib/transparency_and_consent.ex
@@ -1,15 +1,17 @@
 defmodule TransparencyAndConsent do
   @moduledoc """
-  IAB Transparency and Consent String Decoding
+  IAB Transparency and Consent Framework v2.0 String Decoding
 
   Currently only decodes the "version" and the "vendor consents" parts of the "core" segment.
   """
 
   alias TransparencyAndConsent.{DecodeError, Base64, Segment}
 
+  @type vendor_id :: pos_integer()
+
   @type t :: %__MODULE__{
           version: pos_integer(),
-          vendor_consents: [pos_integer()]
+          vendor_consents: [vendor_id()]
         }
 
   defstruct [
@@ -46,6 +48,7 @@ defmodule TransparencyAndConsent do
       iex> TransparencyAndConsent.vendor_has_consent?(%TransparencyAndConsent{vendor_consents: [8, 6, 2]}, 123)
       false
   """
+  @spec vendor_has_consent?(t(), vendor_id()) :: boolean()
   def vendor_has_consent?(%{vendor_consents: consents}, vendor_id) do
     vendor_id in consents
   end

--- a/lib/transparency_and_consent.ex
+++ b/lib/transparency_and_consent.ex
@@ -1,0 +1,60 @@
+defmodule TransparencyAndConsent do
+  @moduledoc """
+  IAB Transparency and Consent String Decoding
+
+  Currently only decodes the "version" and the "vendor consents" parts of the "core" segment.
+  """
+
+  alias TransparencyAndConsent.{DecodeError, Base64, Segment}
+
+  @type t :: %__MODULE__{
+          version: pos_integer(),
+          vendor_consents: [pos_integer()]
+        }
+
+  defstruct [
+    :version,
+    :vendor_consents
+  ]
+
+  @doc """
+  Decodes TCF version 2 strings.
+
+  ## Examples
+
+      iex> TransparencyAndConsent.decode("COvFyGBOvFyGBAbAAAENAPCAAOAAAAAAAAAAAEEUACCKAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw")
+      {:ok, %TransparencyAndConsent{version: 2, vendor_consents: [8, 6, 2]}}
+
+  """
+  @spec decode(binary()) :: {:ok, t()} | {:error, DecodeError.t()}
+  def decode(input) when is_binary(input) do
+    with [core_segment | _] <- String.split(input, "."),
+         {:ok, decoded} <- Base64.decode(core_segment),
+         {:ok, type} <- segment_type(decoded) do
+      Segment.decode_segment(type, decoded, %__MODULE__{})
+    end
+  end
+
+  @doc """
+  Checks if the provided vendor_id is in the list of vendor_consents
+
+  ## Examples
+
+      iex> TransparencyAndConsent.vendor_has_consent?(%TransparencyAndConsent{vendor_consents: [8, 6, 2]}, 8)
+      true
+
+      iex> TransparencyAndConsent.vendor_has_consent?(%TransparencyAndConsent{vendor_consents: [8, 6, 2]}, 123)
+      false
+  """
+  def vendor_has_consent?(%{vendor_consents: consents}, vendor_id) do
+    vendor_id in consents
+  end
+
+  defp segment_type(<<type_bits::binary-size(3), _::binary()>>) do
+    with {type_int, ""} <- Integer.parse(type_bits, 2) do
+      Segment.id_to_segment(type_int)
+    end
+  end
+
+  defp segment_type(_segment), do: {:error, %DecodeError{message: "invalid input"}}
+end

--- a/lib/transparency_and_consent/base64.ex
+++ b/lib/transparency_and_consent/base64.ex
@@ -1,0 +1,51 @@
+defmodule TransparencyAndConsent.Base64 do
+  @moduledoc false
+  alias TransparencyAndConsent.DecodeError
+
+  @charset "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+  @reverse_dict @charset
+                |> String.split("", trim: true)
+                |> Enum.with_index(0)
+                |> Map.new()
+
+  @doc """
+  Decodes a base64url encoded bitfield string to a bitfield string.
+
+  ## Examples
+
+      iex> TransparencyAndConsent.Base64.decode("COvFyGBOvFyGBAbAAAENAPCAAOAAAAAAAAAAAEEUACCKAAA")
+      {:ok, "000010001110101111000101110010000110000001001110101111000101110010000110000001000000011011000000000000000000000100001101000000001111000010000000000000001110000000000000000000000000000000000000000000000000000000000000000000000100000100010100000000000010000010001010000000000000000000"}
+
+  """
+  def decode(input), do: do_decode(input, [])
+
+  defp do_decode(<<>>, acc), do: {:ok, acc |> Enum.reverse() |> Enum.join()}
+
+  defp do_decode(<<char::binary-size(1), rest::binary()>>, acc) do
+    case decode_char(char) do
+      :error ->
+        {:error, %DecodeError{message: "invalid character in segment: `#{char}`"}}
+
+      value ->
+        bitfield_string =
+          value
+          |> Integer.to_string(2)
+          |> pad()
+
+        do_decode(rest, [bitfield_string | acc])
+    end
+  end
+
+  defp pad(string) when byte_size(string) == 6, do: string
+  defp pad(string) when byte_size(string) == 5, do: "0" <> string
+  defp pad(string) when byte_size(string) == 4, do: "00" <> string
+  defp pad(string) when byte_size(string) == 3, do: "000" <> string
+  defp pad(string) when byte_size(string) == 2, do: "0000" <> string
+  defp pad(string) when byte_size(string) == 1, do: "00000" <> string
+
+  for {char, int} <- @reverse_dict do
+    defp decode_char(unquote(char)), do: unquote(int)
+  end
+
+  defp decode_char(_), do: :error
+end

--- a/lib/transparency_and_consent/decode_error.ex
+++ b/lib/transparency_and_consent/decode_error.ex
@@ -1,0 +1,4 @@
+defmodule TransparencyAndConsent.DecodeError do
+  defexception [:message]
+  @type t :: %__MODULE__{message: binary()}
+end

--- a/lib/transparency_and_consent/segment.ex
+++ b/lib/transparency_and_consent/segment.ex
@@ -220,8 +220,6 @@ defmodule TransparencyAndConsent.Segment do
   defp decode_field(:publisher_country_code, _segement, _acc), do: invalid_input_error()
 
   defp decode_field(:vendor_consents, segment, acc) do
-    IO.inspect(segment)
-
     with {:ok, vendor_consents, rest} <- VendorList.decode(segment) do
       {:ok, %{acc | vendor_consents: vendor_consents}, rest}
     end

--- a/lib/transparency_and_consent/segment.ex
+++ b/lib/transparency_and_consent/segment.ex
@@ -1,0 +1,224 @@
+defmodule TransparencyAndConsent.Segment do
+  alias TransparencyAndConsent.{VendorList, DecodeError}
+
+  @supported_version 2
+
+  @segments %{
+    0 => :core,
+    1 => :vendors_disclosed,
+    2 => :vendors_allowed,
+    3 => :publisher_tc
+  }
+
+  @core_fields [
+    :version,
+    :created,
+    :last_updated,
+    :cmp_id,
+    :cmp_version,
+    :consent_screen,
+    :consent_language,
+    :vendor_list_version,
+    :tcf_policy_version,
+    :is_service_specific,
+    :use_non_standard_stacks,
+    :special_feature_opt_ins,
+    :purpose_consents,
+    :publisher_legitimate_interests,
+    :purpose_one_treatment,
+    :publisher_country_code,
+    :vendor_consents,
+    :vendor_legitimate_interests,
+    :publisher_restrictions
+  ]
+
+  for {id, segment} <- @segments do
+    def id_to_segment(unquote(id)), do: {:ok, unquote(segment)}
+    def segment_to_id(unquote(segment)), do: {:ok, unquote(id)}
+  end
+
+  def id_to_segment(_), do: {:error, %DecodeError{message: "unknown segment type"}}
+  def segment_to_id(_), do: {:error, %DecodeError{message: "unknown segment type"}}
+
+  def decode_segment(:core, segment, acc) do
+    Enum.reduce_while(@core_fields, {:ok, acc, segment}, fn field, {:ok, acc, segment} ->
+      case decode_field(field, segment, acc) do
+        {:ok, acc, rest} -> {:cont, {:ok, acc, rest}}
+        error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, acc, _} -> {:ok, acc}
+      error -> error
+    end
+  end
+
+  def decode_segment(_type, _segment, _acc) do
+    {:error, %DecodeError{message: "unsupported segment type"}}
+  end
+
+  defp decode_field(:version, <<version::binary-size(6), rest::binary()>>, acc) do
+    case Integer.parse(version, 2) do
+      {@supported_version, ""} ->
+        {:ok, %{acc | version: @supported_version}, rest}
+
+      {version, ""} ->
+        {:error, %DecodeError{message: "unsupported version: #{version}"}}
+
+      _ ->
+        {:error, %DecodeError{message: "invalid version"}}
+    end
+  end
+
+  defp decode_field(:version, _segment, _acc), do: invalid_input_error()
+
+  defp decode_field(:created, <<_created::binary-size(36), rest::binary()>>, acc) do
+    {:ok, acc, rest}
+  end
+
+  defp decode_field(:created, _segment, _acc), do: invalid_input_error()
+
+  defp decode_field(:last_updated, <<_last_updated::binary-size(36), rest::binary()>>, acc) do
+    {:ok, acc, rest}
+  end
+
+  defp decode_field(:last_updated, _segment, _acc), do: invalid_input_error()
+
+  defp decode_field(:cmp_id, <<_cmp_id::binary-size(12), rest::binary()>>, acc) do
+    {:ok, acc, rest}
+  end
+
+  defp decode_field(:cmp_id, _segment, _acc), do: invalid_input_error()
+
+  defp decode_field(:cmp_version, <<_cmp_version::binary-size(12), rest::binary()>>, acc) do
+    {:ok, acc, rest}
+  end
+
+  defp decode_field(:cmp_version, _segment, _acc), do: invalid_input_error()
+
+  defp decode_field(:consent_screen, <<_consent_screen::binary-size(6), rest::binary()>>, acc) do
+    {:ok, acc, rest}
+  end
+
+  defp decode_field(:consent_screen, _segement, _acc), do: invalid_input_error()
+
+  defp decode_field(
+         :consent_language,
+         <<_consent_language::binary-size(12), rest::binary()>>,
+         acc
+       ) do
+    {:ok, acc, rest}
+  end
+
+  defp decode_field(:consent_language, _segement, _acc), do: invalid_input_error()
+
+  defp decode_field(
+         :vendor_list_version,
+         <<_vendor_list_version::binary-size(12), rest::binary()>>,
+         acc
+       ) do
+    {:ok, acc, rest}
+  end
+
+  defp decode_field(:vendor_list_version, _segement, _acc), do: invalid_input_error()
+
+  defp decode_field(
+         :tcf_policy_version,
+         <<_tcf_policy_version::binary-size(6), rest::binary()>>,
+         acc
+       ) do
+    {:ok, acc, rest}
+  end
+
+  defp decode_field(:tcf_policy_version, _segement, _acc), do: invalid_input_error()
+
+  defp decode_field(
+         :is_service_specific,
+         <<_is_service_specific::binary-size(1), rest::binary()>>,
+         acc
+       ) do
+    {:ok, acc, rest}
+  end
+
+  defp decode_field(:is_service_specific, _segement, _acc), do: invalid_input_error()
+
+  defp decode_field(
+         :use_non_standard_stacks,
+         <<_use_non_standard_stacks::binary-size(1), rest::binary()>>,
+         acc
+       ) do
+    {:ok, acc, rest}
+  end
+
+  defp decode_field(:use_non_standard_stacks, _segement, _acc), do: invalid_input_error()
+
+  defp decode_field(
+         :special_feature_opt_ins,
+         <<_special_feature_opt_ins::binary-size(12), rest::binary()>>,
+         acc
+       ) do
+    {:ok, acc, rest}
+  end
+
+  defp decode_field(:special_feature_opt_ins, _segement, _acc), do: invalid_input_error()
+
+  defp decode_field(
+         :purpose_consents,
+         <<_purpose_consents::binary-size(24), rest::binary()>>,
+         acc
+       ) do
+    {:ok, acc, rest}
+  end
+
+  defp decode_field(:purpose_consents, _segement, _acc), do: invalid_input_error()
+
+  defp decode_field(
+         :publisher_legitimate_interests,
+         <<_publisher_legitimate_interests::binary-size(24), rest::binary()>>,
+         acc
+       ) do
+    {:ok, acc, rest}
+  end
+
+  defp decode_field(:publisher_legitimate_interests, _segement, _acc), do: invalid_input_error()
+
+  defp decode_field(
+         :purpose_one_treatment,
+         <<_purpose_one_treatment::binary-size(1), rest::binary()>>,
+         acc
+       ) do
+    {:ok, acc, rest}
+  end
+
+  defp decode_field(:purpose_one_treatment, _segement, _acc), do: invalid_input_error()
+
+  defp decode_field(
+         :publisher_country_code,
+         <<_publisher_country_code::binary-size(12), rest::binary()>>,
+         acc
+       ) do
+    {:ok, acc, rest}
+  end
+
+  defp decode_field(:publisher_country_code, _segement, _acc), do: invalid_input_error()
+
+  defp decode_field(:vendor_consents, segment, acc) do
+    with {:ok, vendor_consents, rest} <- VendorList.decode(segment) do
+      {:ok, %{acc | vendor_consents: vendor_consents}, rest}
+    end
+  end
+
+  defp decode_field(
+         :vendor_legitimate_interests,
+         <<_vendor_legitimate_interests::binary-size(12), rest::binary()>>,
+         acc
+       ) do
+    {:ok, acc, rest}
+  end
+
+  defp decode_field(:vendor_legitimate_interests, _segement, _acc), do: invalid_input_error()
+
+  defp decode_field(_field, segment, acc), do: {:ok, acc, segment}
+
+  defp invalid_input_error, do: {:error, %DecodeError{message: "invalid input"}}
+end

--- a/lib/transparency_and_consent/segment.ex
+++ b/lib/transparency_and_consent/segment.ex
@@ -1,4 +1,5 @@
 defmodule TransparencyAndConsent.Segment do
+  @moduledoc false
   alias TransparencyAndConsent.{VendorList, DecodeError}
 
   @supported_version 2

--- a/lib/transparency_and_consent/vendor_list.ex
+++ b/lib/transparency_and_consent/vendor_list.ex
@@ -1,4 +1,6 @@
 defmodule TransparencyAndConsent.VendorList do
+  @moduledoc false
+
   alias TransparencyAndConsent.DecodeError
 
   @encoding_type %{
@@ -13,7 +15,7 @@ defmodule TransparencyAndConsent.VendorList do
     end
   end
 
-  def decode(_), do: invalid_input_error() 
+  def decode(_), do: invalid_input_error()
 
   defp do_decode(:field, input, max_id) do
     init = {:ok, [], input}

--- a/lib/transparency_and_consent/vendor_list.ex
+++ b/lib/transparency_and_consent/vendor_list.ex
@@ -1,0 +1,96 @@
+defmodule TransparencyAndConsent.VendorList do
+  @encoding_type %{
+    "0" => :field,
+    "1" => :range
+  }
+
+  def decode(<<max_id::binary-size(16), input::binary()>>) do
+    with {:ok, max_id} <- max_id(max_id),
+         {:ok, encoding_type, input} <- encoding_type(input) do
+      do_decode(encoding_type, input, max_id)
+    end
+  end
+
+  def decode(_), do: {:error, :invalid_input}
+
+  # defp do_decode(:field, input, max_id) when byte_size(input) == max_id do
+  defp do_decode(:field, input, max_id) do
+    init = {:ok, [], input}
+
+    Enum.reduce_while(1..max_id, init, fn
+      i, {:ok, entries, "1" <> rest} ->
+        {:cont, {:ok, [i | entries], rest}}
+
+      _, {:ok, entries, "0" <> rest} ->
+        {:cont, {:ok, entries, rest}}
+
+      _, _ ->
+        {:halt, {:error, :invalid_input}}
+    end)
+  end
+
+  # defp do_decode(:field, input, max_id) do
+  #   {:error, "got input sized #{byte_size(input)} with max id #{max_id}"}
+  # end
+
+  defp do_decode(:range, input, _max_id) do
+    with {:ok, num_entries, rest} <- num_entries(input) do
+      Enum.reduce_while(1..num_entries, {:ok, [], rest}, fn _, {:ok, entries, remaining} ->
+        with {:ok, is_id_range?, remaining} <- is_id_range?(remaining),
+             {:ok, _, _} = result <- extract_entries(remaining, entries, is_id_range?) do
+          {:cont, result}
+        else
+          error -> {:halt, error}
+        end
+      end)
+    end
+  end
+
+  defp extract_entries(
+         <<start_id::binary-size(16), end_id::binary-size(16), rest::binary()>>,
+         entries,
+         true
+       ) do
+    with {start_id, ""} <- Integer.parse(start_id, 2),
+         {end_id, ""} <- Integer.parse(end_id, 2) do
+      updated_entries = Enum.reduce(start_id..end_id, entries, fn id, acc -> [id | acc] end)
+      {:ok, updated_entries, rest}
+    else
+      _ -> {:error, :invalid_input}
+    end
+  end
+
+  defp extract_entries(<<vendor_id::binary-size(16), rest::binary()>>, entries, false) do
+    case Integer.parse(vendor_id, 2) do
+      {vendor_id, ""} -> {:ok, [vendor_id | entries], rest}
+      _ -> {:error, :invalid_input}
+    end
+  end
+
+  defp extract_entries(_, _, _), do: {:error, :invalid_input}
+
+  defp max_id(input) do
+    case Integer.parse(input, 2) do
+      {max_id, ""} -> {:ok, max_id}
+      _ -> {:error, :invalid_input}
+    end
+  end
+
+  defp encoding_type(<<type::binary-size(1), rest::binary()>>) do
+    case Map.get(@encoding_type, type) do
+      nil -> {:error, :invalid_encoding_type}
+      type -> {:ok, type, rest}
+    end
+  end
+
+  defp num_entries(<<num_entries::binary-size(12), rest::binary()>>) do
+    case Integer.parse(num_entries, 2) do
+      {num, ""} -> {:ok, num, rest}
+      _ -> {:error, :invalid_input}
+    end
+  end
+
+  defp is_id_range?("1" <> rest), do: {:ok, true, rest}
+  defp is_id_range?("0" <> rest), do: {:ok, false, rest}
+  defp is_id_range?(_), do: {:error, :invalid_input}
+end

--- a/lib/transparency_and_consent/vendor_list.ex
+++ b/lib/transparency_and_consent/vendor_list.ex
@@ -13,7 +13,6 @@ defmodule TransparencyAndConsent.VendorList do
 
   def decode(_), do: {:error, :invalid_input}
 
-  # defp do_decode(:field, input, max_id) when byte_size(input) == max_id do
   defp do_decode(:field, input, max_id) do
     init = {:ok, [], input}
 
@@ -28,10 +27,6 @@ defmodule TransparencyAndConsent.VendorList do
         {:halt, {:error, :invalid_input}}
     end)
   end
-
-  # defp do_decode(:field, input, max_id) do
-  #   {:error, "got input sized #{byte_size(input)} with max id #{max_id}"}
-  # end
 
   defp do_decode(:range, input, _max_id) do
     with {:ok, num_entries, rest} <- num_entries(input) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,25 @@
+defmodule TransparencyAndConsent.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :transparency_and_consent,
+      version: "0.1.0",
+      elixir: "~> 1.7",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:ex_doc, "~> 0.22", only: :dev, runtime: false}
+    ]
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,12 +1,21 @@
 defmodule TransparencyAndConsent.MixProject do
   use Mix.Project
 
+  @name "TransparencyAndConsent"
+  @version "0.1.0"
+  @repo_url "https://github.com/AppMonet/transparency_and_consent"
+
   def project do
     [
       app: :transparency_and_consent,
-      version: "0.1.0",
+      version: @version,
       elixir: "~> 1.7",
+      description: "Decode IAB Transparency and Consent Framework v1.1 & v2.0 strings.",
+      package: package(),
+      docs: docs(),
       start_permanent: Mix.env() == :prod,
+      name: @name,
+      source_url: @repo_url,
       deps: deps()
     ]
   end
@@ -20,6 +29,22 @@ defmodule TransparencyAndConsent.MixProject do
   defp deps do
     [
       {:ex_doc, "~> 0.22", only: :dev, runtime: false}
+    ]
+  end
+
+  defp package do
+    %{
+      licenses: ["Apache 2"],
+      maintainers: ["Nico Piderman"],
+      links: %{"GitHub" => @repo_url}
+    }
+  end
+
+  defp docs do
+    [
+      main: "TransparencyAndConsent",
+      source_ref: "v#{@version}",
+      source_url: @repo_url
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,7 @@
+%{
+  "earmark_parser": {:hex, :earmark_parser, "1.4.10", "6603d7a603b9c18d3d20db69921527f82ef09990885ed7525003c7fe7dc86c56", [:mix], [], "hexpm", "8e2d5370b732385db2c9b22215c3f59c84ac7dda7ed7e544d7c459496ae519c0"},
+  "ex_doc": {:hex, :ex_doc, "0.22.2", "03a2a58bdd2ba0d83d004507c4ee113b9c521956938298eba16e55cc4aba4a6c", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "cf60e1b3e2efe317095b6bb79651f83a2c1b3edcb4d319c421d7fcda8b3aff26"},
+  "makeup": {:hex, :makeup, "1.0.3", "e339e2f766d12e7260e6672dd4047405963c5ec99661abdc432e6ec67d29ef95", [:mix], [{:nimble_parsec, "~> 0.5", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "2e9b4996d11832947731f7608fed7ad2f9443011b3b479ae288011265cdd3dad"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.1", "4f0e96847c63c17841d42c08107405a005a2680eb9c7ccadfd757bd31dabccfb", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "f2438b1a80eaec9ede832b5c41cd4f373b38fd7aa33e3b22d9db79e640cbde11"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.6.0", "32111b3bf39137144abd7ba1cce0914533b2d16ef35e8abc5ec8be6122944263", [:mix], [], "hexpm", "27eac315a94909d4dc68bc07a4a83e06c8379237c5ea528a9acff4ca1c873c52"},
+}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/test/transparency_and_consent/base64_test.exs
+++ b/test/transparency_and_consent/base64_test.exs
@@ -1,0 +1,4 @@
+defmodule TransparencyAndConsent.Base64Test do
+  use ExUnit.Case
+  doctest TransparencyAndConsent.Base64
+end

--- a/test/transparency_and_consent_test.exs
+++ b/test/transparency_and_consent_test.exs
@@ -7,20 +7,22 @@ defmodule TransparencyAndConsentTest do
       input =
         "CGL23UdMFJzvuA9ACCENAXCEAC0AAGrAAA5YA5ht7-_d_7_vd-f-nrf4_4A4hM4JCKoK4YhmAqABgAEgAA.IFut_a83_Ma_t-_SvB3v4-IAeIAACAIgSAAQAIAgEQACEABAAAgAQFAEAIAAAGBAAgAAAAQAIFAAMCQAAgAAQiRAEQAAAAANAAIAAggAIYQFAAARmggBC3ZCYzU2yIA.QFulWfTw4obx_Z2zUj6XkNIAeIAACAIgSAAQAIAgEQACEABAAAgAQFAEAIAAAGBAAgAAAAQAIFAAMCQAAgAAQiRAEQAAAAANAAIAAggAIYQFAAARmggBC3ZCYzU2yIA"
 
-      assert {:ok, %TransparencyAndConsent{version: 2, vendor_consents: consents}} =
+      assert {:ok, %TransparencyAndConsent{version: 2, vendor_consents: consents} = res} =
                TransparencyAndConsent.decode(input)
 
       assert length(consents) == 91
+      assert TransparencyAndConsent.vendor_has_consent?(res, 111)
     end
 
     test "all segments with `range` type vendor_consents" do
       input =
         "CO4D9fZO4D9fZAGABCENAyCsAP_AAE_AABaYGGQHwAAwAKAAsABoAGQAOAAgABUADIAGgAOoAegB8AEUAJgAUAAwgBoAEJAI4AkABLACiAFaAMsAeAA_QCAAEHAIwAWYBJ4C8wGGAIPAHADQAIQARwAywB4AEAAIOASMgDAAqACYAI4AZYBGAF5iIAYAKgBlgEYCQDQAFgAZAA4ACAAFQANAAfABMAEsAMsAfoBGAF5hoAYAKgBlgEYFQBgAVABMAEcAMsAjAC8x0AwABYAGQAOAAgABUADQAHwATABLAD9AIwAvMhAGAAWABkAFQATABHAEYJQBgAFgAZAA4AEwAjAC8ykAoABYAGQAOAAgABUADQAJgA_QCMALzAAA.YAAAAAAAAAAA"
 
-      assert {:ok, %TransparencyAndConsent{version: 2, vendor_consents: consents}} =
+      assert {:ok, %TransparencyAndConsent{version: 2, vendor_consents: consents} = res} =
                TransparencyAndConsent.decode(input)
 
       assert length(consents) == 35
+      assert TransparencyAndConsent.vendor_has_consent?(res, 143)
     end
 
     test "returns DecodeError for invalid input" do
@@ -32,10 +34,12 @@ defmodule TransparencyAndConsentTest do
       input =
         "BOtn-dKO4E4lPAKAkBITDW-AAAAyN7_______9_-____9uz_Ov_v_f__33e8__9v_l_7_-___u_-23d4u_1vf99yfmx-7etr3tp_47ues2_Xurf_71__3z3_9pxP78E89r7335EQ_v-_t-b7BCHN_Y2v-8K96lPKACE"
 
-      assert {:ok, %TransparencyAndConsent{version: 1, vendor_consents: consents}} =
+      assert {:ok, %TransparencyAndConsent{version: 1, vendor_consents: consents} = res} =
                TransparencyAndConsent.decode(input)
 
       assert length(consents) == 605
+      assert TransparencyAndConsent.vendor_has_consent?(res, 737)
+      refute TransparencyAndConsent.vendor_has_consent?(res, 123_456)
     end
   end
 end

--- a/test/transparency_and_consent_test.exs
+++ b/test/transparency_and_consent_test.exs
@@ -2,7 +2,7 @@ defmodule TransparencyAndConsentTest do
   use ExUnit.Case
   doctest TransparencyAndConsent
 
- describe "decode/1" do
+  describe "decode/1" do
     test "all segments, with `field` type vendor_consents" do
       input =
         "CGL23UdMFJzvuA9ACCENAXCEAC0AAGrAAA5YA5ht7-_d_7_vd-f-nrf4_4A4hM4JCKoK4YhmAqABgAEgAA.IFut_a83_Ma_t-_SvB3v4-IAeIAACAIgSAAQAIAgEQACEABAAAgAQFAEAIAAAGBAAgAAAAQAIFAAMCQAAgAAQiRAEQAAAAANAAIAAggAIYQFAAARmggBC3ZCYzU2yIA.QFulWfTw4obx_Z2zUj6XkNIAeIAACAIgSAAQAIAgEQACEABAAAgAQFAEAIAAAGBAAgAAAAQAIFAAMCQAAgAAQiRAEQAAAAANAAIAAggAIYQFAAARmggBC3ZCYzU2yIA"

--- a/test/transparency_and_consent_test.exs
+++ b/test/transparency_and_consent_test.exs
@@ -28,12 +28,14 @@ defmodule TransparencyAndConsentTest do
                TransparencyAndConsent.decode("WAT")
     end
 
-    test "returns DecodeError for unsupported versions" do
-      v1_input =
-        "BOeLqXmOeLqXmAtABBENCL-AAAAmB7_______9______5uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_9phPrsks9Kg"
+    test "correctly parses version 1.1 as well" do
+      input =
+        "BOtn-dKO4E4lPAKAkBITDW-AAAAyN7_______9_-____9uz_Ov_v_f__33e8__9v_l_7_-___u_-23d4u_1vf99yfmx-7etr3tp_47ues2_Xurf_71__3z3_9pxP78E89r7335EQ_v-_t-b7BCHN_Y2v-8K96lPKACE"
 
-      assert {:error, %TransparencyAndConsent.DecodeError{message: "unsupported version: 1"}} =
-               TransparencyAndConsent.decode(v1_input)
+      assert {:ok, %TransparencyAndConsent{version: 1, vendor_consents: consents}} =
+               TransparencyAndConsent.decode(input)
+
+      assert length(consents) == 605
     end
   end
 end

--- a/test/transparency_and_consent_test.exs
+++ b/test/transparency_and_consent_test.exs
@@ -1,0 +1,39 @@
+defmodule TransparencyAndConsentTest do
+  use ExUnit.Case
+  doctest TransparencyAndConsent
+
+ describe "decode/1" do
+    test "all segments, with `field` type vendor_consents" do
+      input =
+        "CGL23UdMFJzvuA9ACCENAXCEAC0AAGrAAA5YA5ht7-_d_7_vd-f-nrf4_4A4hM4JCKoK4YhmAqABgAEgAA.IFut_a83_Ma_t-_SvB3v4-IAeIAACAIgSAAQAIAgEQACEABAAAgAQFAEAIAAAGBAAgAAAAQAIFAAMCQAAgAAQiRAEQAAAAANAAIAAggAIYQFAAARmggBC3ZCYzU2yIA.QFulWfTw4obx_Z2zUj6XkNIAeIAACAIgSAAQAIAgEQACEABAAAgAQFAEAIAAAGBAAgAAAAQAIFAAMCQAAgAAQiRAEQAAAAANAAIAAggAIYQFAAARmggBC3ZCYzU2yIA"
+
+      assert {:ok, %TransparencyAndConsent{version: 2, vendor_consents: consents}} =
+               TransparencyAndConsent.decode(input)
+
+      assert length(consents) == 91
+    end
+
+    test "all segments with `range` type vendor_consents" do
+      input =
+        "CO4D9fZO4D9fZAGABCENAyCsAP_AAE_AABaYGGQHwAAwAKAAsABoAGQAOAAgABUADIAGgAOoAegB8AEUAJgAUAAwgBoAEJAI4AkABLACiAFaAMsAeAA_QCAAEHAIwAWYBJ4C8wGGAIPAHADQAIQARwAywB4AEAAIOASMgDAAqACYAI4AZYBGAF5iIAYAKgBlgEYCQDQAFgAZAA4ACAAFQANAAfABMAEsAMsAfoBGAF5hoAYAKgBlgEYFQBgAVABMAEcAMsAjAC8x0AwABYAGQAOAAgABUADQAHwATABLAD9AIwAvMhAGAAWABkAFQATABHAEYJQBgAFgAZAA4AEwAjAC8ykAoABYAGQAOAAgABUADQAJgA_QCMALzAAA.YAAAAAAAAAAA"
+
+      assert {:ok, %TransparencyAndConsent{version: 2, vendor_consents: consents}} =
+               TransparencyAndConsent.decode(input)
+
+      assert length(consents) == 35
+    end
+
+    test "returns DecodeError for invalid input" do
+      assert {:error, %TransparencyAndConsent.DecodeError{}} =
+               TransparencyAndConsent.decode("WAT")
+    end
+
+    test "returns DecodeError for unsupported versions" do
+      v1_input =
+        "BOeLqXmOeLqXmAtABBENCL-AAAAmB7_______9______5uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_9phPrsks9Kg"
+
+      assert {:error, %TransparencyAndConsent.DecodeError{message: "unsupported version: 1"}} =
+               TransparencyAndConsent.decode(v1_input)
+    end
+  end
+end


### PR DESCRIPTION
Resources: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md

Reference implementation (much more complete): https://github.com/InteractiveAdvertisingBureau/iabtcf-es